### PR TITLE
show errors when they appear

### DIFF
--- a/mbsync.el
+++ b/mbsync.el
@@ -15,7 +15,7 @@
 
 (defcustom mbsync-exit-hook nil
   "Hook run after `mbsync' is done."
-  :group 'mbysnc
+  :group 'mbsync
   :type 'hook)
 
 (defcustom mbsync-executable (executable-find "mbsync")

--- a/mbsync.el
+++ b/mbsync.el
@@ -31,6 +31,11 @@
   :group 'mbsync
   :type 'boolean)
 
+(defface mbsync-font-lock-error-face
+  '((t (:foreground "yellow" :background "red" :bold t)))
+  "Face description for all errors."
+  :group 'mbsync)
+
 (defvar mbsync-process-filter-pos nil)
 
 (defun mbsync-process-filter (proc string)
@@ -57,6 +62,20 @@
 	(goto-char mbsync-process-filter-pos)
 	(while (re-search-forward (rx bol "Channel " (+ (any alnum)) eol) nil t)
 	  (message "%s" (match-string 0))))
+
+    (let (err-pos)
+      (save-excursion
+        ;; errors
+        (goto-char mbsync-process-filter-pos)
+        (while (re-search-forward (rx bol "Error:" (* anything) eol) nil t)
+          (message "%s" (match-string 0))
+          (overlay-put (make-overlay (match-beginning 0)
+                                     (match-end 0))
+                       'face 'mbsync-font-lock-error-face)
+          (switch-to-buffer-other-window (current-buffer))
+          (setq err-pos (match-beginning 0))))
+      (when err-pos
+        (goto-char err-pos)))
 
     (setq mbsync-process-filter-pos (point-max))))
 

--- a/mbsync.el
+++ b/mbsync.el
@@ -19,12 +19,14 @@
   :type 'hook)
 
 (defcustom mbsync-executable (executable-find "mbsync")
-  "Where to find the `mbsync' utility"
-  :group 'mbsync)
+  "Where to find the `mbsync' utility."
+  :group 'mbsync
+  :type 'string)
 
 (defcustom mbsync-args '("-a")
-  "List of options to pass to the `mbsync' command"
-  :group 'mbsync)
+  "List of options to pass to the `mbsync' command."
+  :group 'mbsync
+  :type '(repeat string))
 
 (defcustom mbsync-auto-accept-certs nil
   "Accept all certificates if true."
@@ -39,7 +41,8 @@
 (defvar mbsync-process-filter-pos nil)
 
 (defun mbsync-process-filter (proc string)
-  "Filter for `mbsync', auto accepting certificates"
+  "Filter for `mbsync', auto accepting certificates.
+Arguments PROC, STRING as in `set-process-filter'."
   (with-current-buffer (process-buffer proc)
     (unless (bound-and-true-p mbsync-process-filter-pos)
       (make-local-variable 'mbsync-process-filter-pos)
@@ -80,20 +83,23 @@
     (setq mbsync-process-filter-pos (point-max))))
 
 (defun mbsync-sentinel (proc change)
-  "Mail sync is over, message it then run `mbsync-exit-hook'"
+  "Mail sync is over, message it then run `mbsync-exit-hook'.
+Arguments PROC, CHANGE as in `set-process-sentinel'."
   (when (eq (process-status proc) 'exit)
     (message "mbsync is done")
     (run-hooks 'mbsync-exit-hook)))
 
+;;;###autoload
 (defun mbsync (&optional show-buffer)
-  "run the `mbsync' command, asynchronously, then run `mbsync-exit-hook'"
+  "Run the `mbsync' command, asynchronously, then run `mbsync-exit-hook'.
+If SHOW-BUFFER, also show the *mbsync* output."
   (interactive "p")
   (let* ((name "*mbsync*")
 	 (dummy (when (get-buffer name) (kill-buffer name)))
 	 (proc (apply 'start-process name name mbsync-executable mbsync-args)))
     (set-process-filter proc 'mbsync-process-filter)
     (set-process-sentinel proc 'mbsync-sentinel)
-    (when (and (called-interactively-p) (eq show-buffer 4))
+    (when (and (called-interactively-p 'any) (eq show-buffer 4))
       (set-window-buffer (selected-window) (process-buffer proc)))))
 
 (provide 'mbsync)

--- a/mbsync.el
+++ b/mbsync.el
@@ -26,6 +26,11 @@
   "List of options to pass to the `mbsync' command"
   :group 'mbsync)
 
+(defcustom mbsync-auto-accept-certs nil
+  "Accept all certificates if true."
+  :group 'mbsync
+  :type 'boolean)
+
 (defvar mbsync-process-filter-pos nil)
 
 (defun mbsync-process-filter (proc string)
@@ -43,7 +48,9 @@
 	;; accept certificates
 	(goto-char mbsync-process-filter-pos)
 	(while (re-search-forward "Accept certificate?" nil t)
-	  (process-send-string proc "y\n"))))
+          (if mbsync-auto-accept-certs
+              (process-send-string proc "y\n")
+            (message "mbsync blocked, waiting for certificate acceptance")))))
 
     (save-excursion
 	;; message progress


### PR DESCRIPTION
Otherwise it's quite possible for mbsync errors to go unnoticed for a while!