### PR TITLE
mbsync.el: Require cl

### DIFF
--- a/mbsync.el
+++ b/mbsync.el
@@ -31,6 +31,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defgroup mbsync nil "mbsync customization group"
   :group 'convenience)
 


### PR DESCRIPTION
cl is required because of incf macro

This commit fixes error message after calling `mbsync` procedure.