### PR TITLE
Use cl-incf instead of incf.

### DIFF
--- a/mbsync.el
+++ b/mbsync.el
@@ -86,7 +86,7 @@
       (dolist (e lst)
         (if (eq e elt)
             (throw 'found i)
-          (incf i))))))
+          (cl-incf i))))))
 
 (defvar mbsync-log-levels '(quiet normal verbose debug))
 


### PR DESCRIPTION
mbsync.el requires cl-lib, which provides the cl-incf macro, but it
uses incf without the cl prefix. The unprefixed incf macro is not
defined in the cl-lib package, so this results in errors when invoking
mbsync.

error in process filter: mbsync-elem-index: Symbol’s function definition is void: incf
error in process filter: Symbol’s function definition is void: incf

Use cl-incf instead.